### PR TITLE
Various smallish changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,8 @@ and [restore and decrypt backups](#restoring-backups) from an S3 bucket.
 
 The following environment variables are required for all sub-commands:
 
-- `S3_ACCESS_KEY`: S3 access key
 - `S3_BUCKET`: S3 bucket
-- `S3_SECRET_KEY`: S3 secret key
-- `S3_URL`: S3 endpoint URL. Must start with `https://`.
+- `S3_URL`: S3 URL including credentials. Must start with `https://`. Ex. `https://<access-key>:<secret-key>@<s3-endpoint>`.
 
 Required for `backup` and `restore` operations:
 


### PR DESCRIPTION
- Add --quiet flags to mc and gpg
- Use variables in error messages
- Use $MC_HOST_alias to pass S3 credentials
- Allow listing the bucket root
- Require $S3_DEST_DIR on backup and restore