### PR TITLE
Separate out S3 credentials and endpoint inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,19 @@ A container that can [encrypt and backup](#creating-backups) contents to an S3 b
 [view](#viewing-backups) the contents of an S3 bucket,
 and [restore and decrypt backups](#restoring-backups) from an S3 bucket.
 
-The following environment variables are required for all sub-commands:
+Requirements
+------------
 
-- `S3_BUCKET`: S3 bucket
-- `S3_URL`: S3 URL including credentials. Must start with `https://`. Ex. `https://<access-key>:<secret-key>@<s3-endpoint>`.
+1.  S3 credentials of the form `access-key:secret-key` must be mounted to `/s3.creds`
 
-Required for `backup` and `restore` operations:
+1.  The following environment variables are required for all sub-commands:
 
-- `S3_DEST_DIR`: target directory relative to `S3_BUCKET` for creating/restoring backups and `ls` operations
+    - `S3_BUCKET`: S3 bucket
+    - `S3_ENDPOINT`: S3 endpoint
 
+1.  The following environment variable is required for `backup` and `restore` operations:
+
+    - `S3_DEST_DIR`: target directory relative to `S3_BUCKET` for creating/restoring backups and `ls` operations
 
 Creating Backups
 ----------------

--- a/s3-backup.sh
+++ b/s3-backup.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+S3_CREDENTIALS=/s3.creds
 ENCRYPTION_KEY=/encryption.key
 INPUT_DIR=/input
 OUTPUT_DIR=/output
@@ -27,7 +28,9 @@ Required environment variables:
 
 - S3_BUCKET
 - S3_DEST_DIR (optional for the 'ls' subcommand)
-- S3_URL (must start with https://)"
+- S3_ENDPOINT
+
+S3 credentials of the form 'access-key:secret-key' must be mounted to '/s3.creds'"
 }
 
 
@@ -119,12 +122,12 @@ case $# in
 esac
 
 # Bail if commonly required S3_* env vars aren't set
-if [[ -z $S3_BUCKET ]] || [[ $S3_URL != https://* ]]; then
+if [[ -z $S3_BUCKET ]] || [[ ! -f $S3_CREDENTIALS ]] || [[ -z $S3_ENDPOINT ]]; then
     usage
 fi
 
 # Configure alias
-export MC_HOST_${S3_ALIAS}="$S3_URL"
+export MC_HOST_${S3_ALIAS}="https://$(tr -d < S3_CREDENTIALS)@${S3_ENDPOINT#https://}"
 
 # Run subcommands
 case "$subcommand" in


### PR DESCRIPTION
- Require S3 creds to be mounted in to avoid potential credential leaks
  through the environment
- Keep the endpoint as an env var so we can more easily tell where
  backups are being sent to (i.e., in k8s yaml)