### PR TITLE
Use bzip2 compression

### DIFF
--- a/s3-backup.sh
+++ b/s3-backup.sh
@@ -53,6 +53,7 @@ mc_backup () {
         --output "$BACKUP.enc" \
         --symmetric \
         --cipher-algo AES256 \
+        --compress-algo bzip2 \
         $BACKUP
 
     mc cp \

--- a/s3-backup.sh
+++ b/s3-backup.sh
@@ -54,6 +54,7 @@ mc_backup () {
         --symmetric \
         --cipher-algo AES256 \
         --compress-algo bzip2 \
+        --bzip2-compress-level 9 \
         $BACKUP
 
     mc cp \


### PR DESCRIPTION
Did a quick test on a Nebraska etcd export. xz drops it to 3%: 386M to 11M.