### PR TITLE
Take `--fake` and `--remove` out of `mc mirror` arguments

### DIFF
--- a/s3-backup.sh
+++ b/s3-backup.sh
@@ -126,10 +126,8 @@ mc_mirror() {
     [[ -n $S3_DEST_DIR ]] || fail "ERROR: \$S3_DEST_DIR is required"
 
     mc mirror \
-       --fake `# FIXME: For initial testing` \
        --quiet \
        --overwrite \
-       --remove \
        "$S3_SRC_ALIAS/$S3_SRC_BUCKET" \
        "$S3_ALIAS/$S3_BUCKET/$S3_DEST_DIR/"
 }


### PR DESCRIPTION
I had included `--fake` for initial testing, but without the `--remove` argument, the risk is much lower.

BrianB didn't think the `--remove` flag was necessary for harbor backups.